### PR TITLE
Update for osg-htc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This repository contains the documents for the OSG Outreach Area.
 
-- [Github hosted](http://opensciencegrid.github.io/outreach/)
+- [Github hosted](http://osg-htc.org/outreach/)
 
 ## Other OSG documentation on Github
 
-- [OSG Council](https://opensciencegrid.github.io/council)
-- [OSG Production](https://opensciencegrid.github.io/production)
+- [OSG Council](https://osg-htc.org/council)
+- [OSG Production](https://osg-htc.org/production)
 
 ## Resources
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,13 +8,13 @@ The goal of the Open Science Grid (OSG) Outreach area is to inform people about 
 The OSG runs the OSG User School, an annual education event for researchers who want to learn to use DHTC methods and
 tools.  It is held each summer at the University of Wisconsin–Madison.
 
-- [OSG User School 2022](https://opensciencegrid.org/user-school-2022/) — 25–29 July 2022
-- [OSG Virtual School 2021](https://opensciencegrid.org/virtual-school-2021/) &mdash; 2&ndash;13 August 2021
-- [OSG Virtual School Pilot 2020](https://opensciencegrid.org/virtual-school-pilot-2020/) — 13&ndash;24 July 2020
-- [OSG User School 2020](https://opensciencegrid.org/user-school-2020/) — canceled due to COVID-19, see above instead
-- [OSG User School 2019](https://opensciencegrid.org/user-school-2019/) — 15–19 July 2019
-- [OSG User School 2018](https://opensciencegrid.org/user-school-2018/) — 9–13 July 2018
-- [OSG User School 2017](https://opensciencegrid.org/user-school-2017/) — 17–21 July 2017
+- [OSG User School 2022](https://osg-htc.org/user-school-2022/) — 25–29 July 2022
+- [OSG Virtual School 2021](https://osg-htc.org/virtual-school-2021/) &mdash; 2&ndash;13 August 2021
+- [OSG Virtual School Pilot 2020](https://osg-htc.org/virtual-school-pilot-2020/) — 13&ndash;24 July 2020
+- [OSG User School 2020](https://osg-htc.org/user-school-2020/) — canceled due to COVID-19, see above instead
+- [OSG User School 2019](https://osg-htc.org/user-school-2019/) — 15–19 July 2019
+- [OSG User School 2018](https://osg-htc.org/user-school-2018/) — 9–13 July 2018
+- [OSG User School 2017](https://osg-htc.org/user-school-2017/) — 17–21 July 2017
 - [OSG User School 2016](/past-schools) — 25–29 July 2016
 - [OSG User School 2015](/past-schools) — 27–31 July 2015
 - [OSG User School 2014](/past-schools) — 7–10 July 2014

--- a/docs/past-schools.md
+++ b/docs/past-schools.md
@@ -1,7 +1,7 @@
 # Past OSG User and Summer Schools
 
 Starting in 2018, the website that hosted the OSG User Schools and (original) OSG Summer Schools from 2010 through 2017
-was shut down.  The [OSG User School 2017](https://opensciencegrid.org/user-school-2017) and later are hosted on a
+was shut down.  The [OSG User School 2017](https://osg-htc.org/user-school-2017) and later are hosted on a
 new platform.
 
 Due to the effort required to convert the old website content to the new system, we have no plans to convert the OSG


### PR DESCRIPTION
All opensciencegrid.org/** websites have been moved so this is the final clean up of existing pointers to the previous locations.

Another pass will be done in the future to clean up **.opensciencegrid.org subdomains when they are transferred.